### PR TITLE
Refactor CLI and add filter paramters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 venv/
 __pycache__/
 *.egg-info/
+.idea/
+build/

--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@ endpoint addresses in the script.
 Open the [bounding box tool](https://boundingbox.klokantech.com/),
 draw a box, choose "CSV" format below, and copy the numbers. Then do:
 
-    osm_to_sandbox 1.2,3.4,5.6,7.8
+    osm_to_sandbox 1.2,3.4,5.6,7.8 -auth
 
-Where numbers are your bbox. The script would download the data from both
-servers, and then it would ask you for your login and password to the Sandbox.
-[Get these here](https://master.apis.dev.openstreetmap.org/user/new).
-Then it would start doing its uploading work.
+Where numbers are your bbox. The `-auth` flag is required and will prompt for the Sandbox username and password. [Get these here](https://master.apis.dev.openstreetmap.org/user/new). The script would download the data from both
+servers, then it would start doing its uploading work.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ endpoint addresses in the script.
 Open the [bounding box tool](https://boundingbox.klokantech.com/),
 draw a box, choose "CSV" format below, and copy the numbers. Then do:
 
-    osm_to_sandbox 1.2,3.4,5.6,7.8 -auth
+    osm_to_sandbox 1.2,3.4,5.6,7.8 --auth
 
-Where numbers are your bbox. The `-auth` flag is required and will prompt for the Sandbox username and password. [Get these here](https://master.apis.dev.openstreetmap.org/user/new). The script would download the data from both
+Where numbers are your bbox. The `--auth` flag is required and will prompt for the Sandbox username and password. [Get these here](https://master.apis.dev.openstreetmap.org/user/new). The script would download the data from both
 servers, then it would start doing its uploading work.
 
 ## Author

--- a/osm_to_sandbox/osm_to_sandbox.py
+++ b/osm_to_sandbox/osm_to_sandbox.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-
 import requests
 import sys
 import getpass
@@ -403,8 +402,8 @@ def cli():
     )
     parser = add_args(parser)
     args = parser.parse_args()
-    args.bbox = [float(x.strip()) for x in args.bbox.split(',')]
-    main(args.bbox, args.auth_header, args.overpass_api)
+    bbox = [float(x.strip()) for x in args.bbox.split(',')]
+    main(bbox, args.auth_header, args.overpass_api)
 
 
 def add_args(parser):
@@ -413,7 +412,7 @@ def add_args(parser):
         help="The target bounding box in format minlon,minlat,maxlon,maxlat. "
              "Get the bounding box from https://boundingbox.klokantech.com/.",
     )
-    parser.add_argument("-auth",
+    parser.add_argument("--auth", "-a",
                         required=True,
                         help="This flag will spawn a password prompt before entering "
                              "the program. Authentication is necessary to upload data "
@@ -421,7 +420,7 @@ def add_args(parser):
                         dest='auth_header',
                         action=AuthPromptAction,
                         type=str)
-    parser.add_argument("--overpassURL",
+    parser.add_argument("--overpass",
                         required=False,
                         help="Use a custom overpass API instance "
                              f"(default: {OVERPASS_API}).",


### PR DESCRIPTION
This PR adds the filter option for tags and attic data to the overpass request as well as enabling custom overpass instances. 
In addition the CLI is refactored to make way for a python API (function parameters) and also make use of argparse. Splitting the parser creation and the argument augmentation into different functions will enable users to add these arguments to their own parser.
The PR otherwise aims to leave the original code as untouched as possible.

closes #1 and closes #2 