### PR TITLE
Make sandbox a 1:1 copy of current OSM

### DIFF
--- a/osm_to_sandbox/osm_to_sandbox.py
+++ b/osm_to_sandbox/osm_to_sandbox.py
@@ -368,25 +368,24 @@ def main(bbox, auth_header, overpass_api=OVERPASS_API, filter_str=None, date_str
             sys.exit(0)
     if not sandbox_elements:
         print('Sandbox is empty there.')
+    else:
+        print('Clearing the area on the sandbox server.')
+        delete_elements(sandbox_elements, auth_header)
 
     elements = download_from_overpass(bbox,
                                       overpass_api,
                                       filter_str=filter_str,
                                       date_str=date_str)
-    filter_by_bbox(elements, bbox)
-    delete_missing(elements)
-    delete_unreferenced_nodes(elements)
+    # filter_by_bbox(elements, bbox)
+    # delete_missing(elements)
+    # delete_unreferenced_nodes(elements)
 
     if not elements:
-        raise IndexError('No elements in the given bounding box')
-    else:
-        print(f'Downloaded {len(elements)} elements.')
+        print('No elements in the given bounding box')
+        return
+    print(f'Downloaded {len(elements)} elements.')
 
     # write_osc_and_exit(elements, open('test.osc', 'w'))
-
-    if sandbox_elements:
-        print('Clearing the area on the sandbox server.')
-        delete_elements(sandbox_elements, auth_header)
 
     print('Uploading new data.')
     upload_elements(elements, auth_header)

--- a/osm_to_sandbox/osm_to_sandbox.py
+++ b/osm_to_sandbox/osm_to_sandbox.py
@@ -235,7 +235,8 @@ def download_from_overpass(bbox, overpass_api, filter_str=None, date_str=None):
     date_para = f'[date:"{date_str}"]' if date_str else ""
     filter_para = f'[{filter_str}]' if filter_str else ""
     query = (f'[timeout:300]{date_para}[bbox:{bbox_para}];'
-             f'(nwr{filter_para};>;);'
+             f'(nwr{filter_para};);'
+             '(_.;>;);'
              # 'nwr._;' # This will produce results equivalent to the former version of the tool but may destroy larger objects.
              'out meta qt;')
     resp = requests.get(f'{overpass_api}/interpreter', {'data': query})


### PR DESCRIPTION
This PR

- makes the recursive overpass query more explicit
- makes the sandbox an exact copy of the current OSM data by 
  - always cleaning the sandbox,
  - allowing empty uploads (meaning that the sandbox stays empty just as the OSM database is at that location), 
  - skipping any data filtering.

Especially the last point may be a question of taste, so feel free to comment or close the PR, I just wanted to share the edits I make in my local version.`filter_by_bbox` may be better done in overpass by including line 239/240 (as it was before). Yet this will destroy larger objects. `delete_missing' may prevent upload errors but should not occur for the recursive query. So this way users will be informed about broken data instead of having it silently removed. `delete_unreferenced_nodes` is a cleaning step that is not in line of making the sandbox a 1:1 copy.